### PR TITLE
Add some lowlevel accessor functions

### DIFF
--- a/bimap.go
+++ b/bimap.go
@@ -124,4 +124,3 @@ func (b *biMap) Lock() {
 func (b *biMap) Unlock() {
 	b.s.Unlock()
 }
-

--- a/bimap.go
+++ b/bimap.go
@@ -108,3 +108,20 @@ func (b *biMap) MakeImmutable() {
 	defer b.s.Unlock()
 	b.immutable = true
 }
+
+func (b *biMap) GetInverseMap() map[interface{}]interface{} {
+	return b.inverse
+}
+
+func (b *biMap) GetForwardMap() map[interface{}]interface{} {
+	return b.forward
+}
+
+func (b *biMap) Lock() {
+	b.s.Lock()
+}
+
+func (b *biMap) Unlock() {
+	b.s.Unlock()
+}
+

--- a/bimap_test.go
+++ b/bimap_test.go
@@ -2,6 +2,7 @@ package bimap
 
 import (
 	"github.com/stretchr/testify/assert"
+	"reflect"
 	"testing"
 )
 
@@ -190,4 +191,34 @@ func TestBiMap_MakeImmutable(t *testing.T) {
 
 	assert.Equal(t, 1, size, "Size should be one")
 
+}
+
+func TestBiMap_GetForwardMap(t *testing.T) {
+	actual := NewBiMap()
+	dummyKey := "Dummy key"
+	dummyVal := 42
+
+	forwardMap := make(map[interface{}]interface{})
+	forwardMap[dummyKey] = dummyVal
+
+	actual.Insert(dummyKey, dummyVal)
+
+	actualForwardMap := actual.GetForwardMap()
+	eq := reflect.DeepEqual(actualForwardMap, forwardMap)
+	assert.True(t, eq, "Forward maps should be equal")
+}
+
+func TestBiMap_GetInverseMap(t *testing.T) {
+	actual := NewBiMap()
+	dummyKey := "Dummy key"
+	dummyVal := 42
+
+	inverseMap := make(map[interface{}]interface{})
+	inverseMap[dummyVal] = dummyKey
+
+	actual.Insert(dummyKey, dummyVal)
+
+	actualInverseMap := actual.GetInverseMap()
+	eq := reflect.DeepEqual(actualInverseMap, inverseMap)
+	assert.True(t, eq, "Inverse maps should be equal")
 }


### PR DESCRIPTION
It was not possible to retrieve the underlying maps of the bimap e.g. to iterate
over the keys or the values.

I added some getters for the forward and inverse maps as well as Lock and Unlock functions.
I have to mention that those functions are low level and should only be used to read values.